### PR TITLE
chore: .gitignore에 불필요한 android 관련 캐시 및 파일들 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,35 @@
-node_modules
+# OS 기본 무시 파일
+.DS_Store
+._*
+Thumbs.db
+
+# 개발 환경
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
 .env
-.vscode
-android/app/build
+.env.local
+
+# Android
+android/.gradle/
+android/app/build/
+android/build/
+local.properties
+android/keystores/debug.keystore
+
+# 캐시/로그
+*.log
+*.tmp
+*.bak
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# React Native
+/android/app/debug
+/android/app/release
+/android/app/.cxx/


### PR DESCRIPTION
## #️⃣ Issue Number #9 

## 📝 세부 내용
- React Native 프로젝트에서 Android 빌드 및 개발 과정에서 생성되는 캐시 파일(.gradle, /build 등)과 불필요한 파일이 저장소에 다수 포함되는 문제가 있었습니다.

## 💬 리뷰 요청 사항
- gitignore에 추가된 파일/폴더 목록이 프로젝트 상황에 적합한지 확인 부탁드립니다.

- 혹시 추가적으로 제외해야 할 파일이나 폴더가 있다면 의견 주시면 반영하겠습니다.

